### PR TITLE
Deal with multiple child levels in the spec document

### DIFF
--- a/doc/content/specs/nidm-results_dev.html
+++ b/doc/content/specs/nidm-results_dev.html
@@ -371,7 +371,7 @@
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> dimensions of some N-dimensional data. (range <a title="xsd:string" href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:inWorldCoordinateSystem">
                         <dfn>nidm:inWorldCoordinateSystem</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:WorldCoordinateSystem</a> such as <a>nidm:CustomCoordinateSystem</a>, <a>nidm:MNICoordinateSystem</a>, <a>nidm:StandardizedCoordinateSystem</a>, <a>nidm:SubjectCoordinateSystem</a> or <a>nidm:TalairachCoordinateSystem</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> type of coordinate system. (range <a>nidm:WorldCoordinateSystem</a> such as <a>nidm:StandardizedCoordinateSystem</a> or <a>nidm:SubjectCoordinateSystem</a>)</li> 
                         <li><span class="attribute" id="nidm:CoordinateSpace.nidm:numberOfDimensions">
                         <dfn>nidm:numberOfDimensions</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> number of dimensions of a data matrix. (range <a title="xsd:positiveInteger" href="http://www.w3.org/2001/XMLSchema#positiveInteger">xsd:positiveInteger</a>)</li> 
@@ -558,7 +558,7 @@
                      
                         <li><span class="attribute" id="nidm:ModelParametersEstimation.nidm:withEstimationMethod">
                         <dfn>nidm:withEstimationMethod</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="obo:STATO_0000119" href="http://purl.obolibrary.org/obo/STATO_0000119">obo:'model parameter estimation'</a> such as <a title="obo:STATO_0000370" href="http://purl.obolibrary.org/obo/STATO_0000370">obo:'ordinary least squares estimation'</a>, <a title="obo:STATO_0000371" href="http://purl.obolibrary.org/obo/STATO_0000371">obo:'weighted least squares estimation'</a>, <a title="obo:STATO_0000372" href="http://purl.obolibrary.org/obo/STATO_0000372">obo:'generalized least squares estimation'</a>, <a title="obo:STATO_0000373" href="http://purl.obolibrary.org/obo/STATO_0000373">obo:'iteratively reweighted least squares estimation'</a> or <a title="obo:STATO_0000374" href="http://purl.obolibrary.org/obo/STATO_0000374">obo:'feasible generalized least squares estimation'</a>)</li>        
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> fIXME. (range <a title="obo:STATO_0000119" href="http://purl.obolibrary.org/obo/STATO_0000119">obo:'model parameter estimation'</a> such as <a title="obo:STATO_0000370" href="http://purl.obolibrary.org/obo/STATO_0000370">obo:'ordinary least squares estimation'</a>, <a title="obo:STATO_0000371" href="http://purl.obolibrary.org/obo/STATO_0000371">obo:'weighted least squares estimation'</a>, <a title="obo:STATO_0000372" href="http://purl.obolibrary.org/obo/STATO_0000372">obo:'generalized least squares estimation'</a> or <a title="obo:STATO_0000373" href="http://purl.obolibrary.org/obo/STATO_0000373">obo:'iteratively reweighted least squares estimation'</a>)</li>        
                 </ul>
                 </div>
                 <pre class='example highlight'>niiri:model_pe_id prov:used niiri:error_model_id ;
@@ -607,10 +607,10 @@
                      
                         <li><span class="attribute" id="nidm:DesignMatrix.nidm:hasHRFBasis">
                         <dfn>nidm:hasHRFBasis</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:HemodynamicResponseFunctionBasis</a> such as <a>afni:BLOCK</a>, <a>afni:FiniteImpulseResponseHRB</a>, <a>afni:GammaHRF</a>, <a>fsl:CustomHRB</a>, <a>fsl:FiniteImpulseResponseHRB</a>, <a>fsl:GammaDifferenceHRF</a>, <a>fsl:GammaHRB</a>, <a>fsl:GammaHRF</a>, <a>fsl:GaussianHRF</a>, <a>fsl:NoHRF</a>, <a>fsl:SineHRB</a>, <a>fsl:TemporalDerivative</a>, <a>nidm:FiniteImpulseResponseHRB</a>, <a>nidm:GammaDifferenceHRF</a>, <a>nidm:GammaHRB</a>, <a>nidm:GammaHRF</a>, <a>nidm:HemodynamicResponseFunction</a>, <a>nidm:HemodynamicResponseFunctionDerivative</a>, <a>spm:DispersionDerivative</a>, <a>spm:FiniteImpulseResponseHRB</a>, <a>spm:FourierHRB</a>, <a>spm:GammaDifferenceHRF</a>, <a>spm:GammaHRB</a> or <a>spm:TemporalDerivative</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:HemodynamicResponseFunctionBasis</a> such as <a>afni:BLOCK</a>, <a>fsl:CustomHRB</a>, <a>fsl:SineHRB</a>, <a>nidm:FiniteImpulseResponseHRB</a>, <a>nidm:GammaHRB</a>, <a>nidm:HemodynamicResponseFunction</a>, <a>nidm:HemodynamicResponseFunctionDerivative</a> or <a>spm:FourierHRB</a>)</li> 
                         <li><span class="attribute" id="nidm:DesignMatrix.nidm:hasHemodynamicResponseFunction">
                         <dfn>nidm:hasHemodynamicResponseFunction</dfn>
-                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:HemodynamicResponseFunction</a> such as <a>afni:GammaHRF</a>, <a>fsl:GammaDifferenceHRF</a>, <a>fsl:GammaHRF</a>, <a>fsl:GaussianHRF</a>, <a>fsl:NoHRF</a>, <a>nidm:GammaDifferenceHRF</a>, <a>nidm:GammaHRF</a> or <a>spm:GammaDifferenceHRF</a>)</li> 
+                        </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:HemodynamicResponseFunction</a> such as <a>fsl:GaussianHRF</a>, <a>fsl:NoHRF</a>, <a>nidm:GammaDifferenceHRF</a> or <a>nidm:GammaHRF</a>)</li> 
                         <li><span class="attribute" id="nidm:DesignMatrix.nidm:hasHemodynamicResponseFunctionDerivative">
                         <dfn>nidm:hasHemodynamicResponseFunctionDerivative</dfn>
                         </span>: an <em class="rfc2119" title="OPTIONAL">OPTIONAL</em> . (range <a>nidm:HemodynamicResponseFunctionDerivative</a> such as <a>fsl:TemporalDerivative</a>, <a>spm:DispersionDerivative</a> or <a>spm:TemporalDerivative</a>)</li>        

--- a/scripts/OwlReader.py
+++ b/scripts/OwlReader.py
@@ -35,6 +35,15 @@ class OwlReader():
 
         return sub_types
 
+    def get_direct_children(self, term):
+        # Find all direct children of 'term'
+        children = set();
+
+        for class_name in self.graph.subjects(RDFS['subClassOf'], term):
+            children.add(class_name)
+
+        return children
+
     def get_class_names_by_prov_type(self, classes=None, prefix=None, but=None):
         class_names = dict()
         # We at least want to have an output for Entity, Activity and Agent

--- a/scripts/owl_to_webpage.py
+++ b/scripts/owl_to_webpage.py
@@ -275,10 +275,16 @@ class OwlSpecification(object):
                         nidm_namespace = False
                         if self._get_name(list(self.owl.ranges[att])[0]).startswith("nidm") or \
                            self._get_name(list(self.owl.ranges[att])[0]).startswith("fsl") or \
-                           self._get_name(list(self.owl.ranges[att])[0]).startswith("spm"):
+                           self._get_name(list(self.owl.ranges[att])[0]).startswith("spm") or \
+                           self._get_name(list(self.owl.ranges[att])[0]).startswith("afni"):
                             nidm_namespace = True
                             
-                        child_ranges = sorted(self.owl.ranges[att] - self.owl.parent_ranges[att])
+                        # child_ranges = sorted(self.owl.ranges[att] - self.owl.parent_ranges[att])
+                        child_ranges = list()
+                        for parent_range in self.owl.parent_ranges[att]:
+                            child_ranges += self.owl.get_direct_children(parent_range)
+                        child_ranges = sorted(child_ranges)
+
                         if nidm_namespace:
                             child_range_txt = ""
                             if child_ranges:


### PR DESCRIPTION
Now display only direct children after "such as". By following the links we should be able to get to all children.