### PR TITLE
Remove "-" in variable names

### DIFF
--- a/nidm/nidm-results/scripts/create_example_from_templates.py
+++ b/nidm/nidm-results/scripts/create_example_from_templates.py
@@ -125,7 +125,9 @@ class ExampleFromTemplate(object):
         for idt in alphanum_ids:
             term_uri = NIDM[idt.split(":")[1]]
             prefix_name = self.owl.get_label(term_uri).replace(" ", "")\
-                            .replace(":", "_").replace("'", "")+":"
+                                                      .replace(":", "_")\
+                                                      .replace("'", "")\
+                                                      .replace("-", "")+":"
             prefix_definition = "@prefix "+prefix_name+" <"+str(term_uri)+"> .\n"
             if not prefix_definition in prefix_definitions:
                 prefix_definitions += prefix_definition

--- a/nidm/nidm-results/scripts/semantic_to_alphanumeric_id.py
+++ b/nidm/nidm-results/scripts/semantic_to_alphanumeric_id.py
@@ -73,7 +73,8 @@ def main(sid, aid, owl_file, template_files, script_files,
     for scr, scr_txt in scripts_txt.items():
         scripts_txt[scr] = scr_txt.replace('"'+sid+'"', '"'+aid+'"')
 
-    new_constant = "NIDM_" + label.upper().replace(" ", "_") + \
+    new_constant = "NIDM_" + \
+                   label.upper().replace(" ", "_").replace("-", "_") + \
                    " = NIDM['"+aid.replace("nidm:", "")+"']"
     cst_txt = cst_txt.replace("# NIDM constants",
                               "# NIDM constants\n"+new_constant)


### PR DESCRIPTION
When a label contains a "-" replace it by "" or "_" when creating a variable name from it (for alphanumeric identifiers).